### PR TITLE
Add Spring Boot Kafka producer and consumer modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Maven 빌드 아웃풋
+**/target/
+
+# IntelliJ IDEA 등 IDE 설정
+.idea/
+*.iml
+
+# OS 별 숨김 파일
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,40 +1,60 @@
-# Spring Boot 환경에서 Kafka 실습 프롬프트
+# Spring Boot 환경에서 Kafka 실습 예제
+
+이 저장소는 README의 가이드에 따라 Kafka 환경을 학습할 수 있도록 두 개의 스프링 부트 모듈(이벤트 프로듀서, 이벤트 컨슈머)과 Kafka/Zookeeper를 실행하는 Docker Compose 파일을 제공합니다.
 
 ## 1. Kafka 및 환경 세팅
 
-- Docker를 활용하여 Kafka 및 Zookeeper 컨테이너 생성
-  - Kafka와 Zookeeper 도커 이미지를 다운로드 받고 실행
+- `docker-compose.yml` 파일을 이용해 Kafka와 Zookeeper 컨테이너를 실행합니다.
+  ```bash
+  docker compose up -d
+  ```
+- Java 17 이상과 Maven이 설치된 환경에서 프로젝트를 빌드합니다.
 
-- Spring Boot 프로젝트 생성
-  - Maven, Java 17 이상, Lombok, Spring Web, Spring for Kafka 포함
-  - 프로젝트 이름 예: kafka-demo
+## 2. 모듈 구조
 
-## 2. 모듈화 구조 구성
+| 모듈 | 설명 |
+| --- | --- |
+| `event-producer` | REST API(`/publish`)를 통해 메시지를 Kafka로 전송하고, 설정에 따라 자동 발행 기능을 제공합니다. |
+| `event-consumer` | Kafka 토픽을 구독하여 메시지를 수신하고, `/messages` API로 최근 메시지를 확인할 수 있습니다. |
 
-### 서버 1: 이벤트 발생 서버
-- Spring Boot REST API로 이벤트 수동/자동 생성
-- 예: `/publish` 엔드포인트 호출로 메시지를 Kafka에 전송
+각 모듈은 독립적으로 실행 가능한 Spring Boot 애플리케이션이며, 공통 토픽 이름과 Kafka 접속 정보를 `application.yml`에서 공유합니다.
 
-### 서버 2: Kafka 연동 서버
-- Kafka 메시지 구독 Consumer 구현
-- 수신된 메시지 콘솔 출력 또는 간단 UI에서 확인 가능
+## 3. 빌드 및 실행
 
-### 실행 방식
-- 두 서버를 IDE 내 모듈 또는 별도 프로젝트로 구성하여 각각 실행
-- Docker Compose로 Kafka와 두 서버 동시 실행 스크립트 작성 가능
+```bash
+mvn clean package
+```
 
-## 3. Kafka와 Spring Boot 연동
+### 이벤트 프로듀서 서버 실행
+```bash
+cd event-producer
+mvn spring-boot:run
+```
 
-- `spring-kafka` 의존성 추가 및 설정
-- Kafka 서버 주소 (`localhost:9092`) 설정
-- Producer, Consumer 설정 bean 작성
+### 이벤트 컨슈머 서버 실행
+```bash
+cd event-consumer
+mvn spring-boot:run
+```
 
-## 4. 실습 단계
+## 4. API 사용 예시
 
-1. Docker로 Kafka와 Zookeeper 컨테이너 실행
-2. Spring Boot 프로젝트에서 Kafka 의존성 추가 및 설정
-3. 서버 1의 `/publish` 엔드포인트 호출해 메시지 전송
-4. 서버 2에서 메시지 로그 출력 확인
-5. UI 또는 터미널로 메시지 흐름 육안 확인 가능
+- **수동 발행:**
+  ```bash
+  curl -X POST \
+       -H "Content-Type: application/json" \
+       -d '{"message": "Hello Kafka"}' \
+       http://localhost:8080/publish
+  ```
+- **수신 메시지 조회:**
+  ```bash
+  curl http://localhost:8081/messages
+  ```
 
----
+## 5. 자동 발행 기능
+
+`event-producer/src/main/resources/application.yml`에서 `demo.auto-publish.enabled` 값을 `true`로 변경하면 설정된 간격(`interval`)마다 메시지가 자동 전송됩니다.
+
+## 6. 테스트
+
+모듈 별 기본 컨텍스트 로딩 테스트가 포함되어 있으며, Kafka 인스턴스 없이도 실행될 수 있도록 테스트 전용 설정이 추가되어 있습니다.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.1
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1

--- a/event-consumer/pom.xml
+++ b/event-consumer/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>simple-kafka</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>event-consumer</artifactId>
+    <name>event-consumer</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/event-consumer/src/main/java/com/example/consumer/ConsumerApplication.java
+++ b/event-consumer/src/main/java/com/example/consumer/ConsumerApplication.java
@@ -1,0 +1,19 @@
+package com.example.consumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Kafka 메시지를 구독하는 컨슈머 서버의 진입점.
+ */
+@SpringBootApplication
+public class ConsumerApplication {
+
+    /**
+     * 스프링 부트 애플리케이션을 실행한다.
+     * @param args 커맨드라인 인자
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(ConsumerApplication.class, args);
+    }
+}

--- a/event-consumer/src/main/java/com/example/consumer/controller/MessageController.java
+++ b/event-consumer/src/main/java/com/example/consumer/controller/MessageController.java
@@ -1,0 +1,32 @@
+package com.example.consumer.controller;
+
+import com.example.consumer.service.MessageStorage;
+import com.example.consumer.service.MessageStorage.StoredMessage;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 수신한 메시지를 조회하기 위한 REST 컨트롤러.
+ */
+@RestController
+@RequestMapping("/messages")
+public class MessageController {
+
+    /** 저장된 메시지를 제공하는 저장소 */
+    private final MessageStorage messageStorage;
+
+    public MessageController(MessageStorage messageStorage) {
+        this.messageStorage = messageStorage;
+    }
+
+    /**
+     * 저장된 메시지 전체를 반환한다.
+     * @return 메시지 목록
+     */
+    @GetMapping
+    public List<StoredMessage> list() {
+        return messageStorage.getMessages();
+    }
+}

--- a/event-consumer/src/main/java/com/example/consumer/service/MessageListener.java
+++ b/event-consumer/src/main/java/com/example/consumer/service/MessageListener.java
@@ -1,0 +1,32 @@
+package com.example.consumer.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Kafka 토픽을 구독하여 수신한 메시지를 저장소에 적재하고 로그를 남기는 리스너.
+ */
+@Component
+public class MessageListener {
+
+    private static final Logger log = LoggerFactory.getLogger(MessageListener.class);
+
+    /** 수신 메시지를 저장할 저장소 */
+    private final MessageStorage messageStorage;
+
+    public MessageListener(MessageStorage messageStorage) {
+        this.messageStorage = messageStorage;
+    }
+
+    /**
+     * KafkaListener 어노테이션으로 demo-topic을 구독한다.
+     * @param payload 수신된 메시지 본문
+     */
+    @KafkaListener(topics = "${demo.topic-name:demo-topic}", groupId = "demo-consumer")
+    public void listen(String payload) {
+        log.info("Kafka에서 메시지를 수신했습니다: {}", payload);
+        messageStorage.add(payload);
+    }
+}

--- a/event-consumer/src/main/java/com/example/consumer/service/MessageStorage.java
+++ b/event-consumer/src/main/java/com/example/consumer/service/MessageStorage.java
@@ -1,0 +1,63 @@
+package com.example.consumer.service;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * 수신한 메시지를 메모리에 보관하여 REST API로 조회할 수 있도록 돕는 저장소.
+ */
+@Component
+public class MessageStorage {
+
+    /** 조회 시 최신 순으로 반환하기 위해 연결 리스트 사용 */
+    private final LinkedList<StoredMessage> messages = new LinkedList<>();
+
+    /** 최대 보관 개수 (무한 성장 방지) */
+    private final int maxSize = 100;
+
+    /**
+     * 새로운 메시지를 저장한다.
+     * @param payload 수신한 메시지 본문
+     */
+    public synchronized void add(String payload) {
+        messages.addFirst(new StoredMessage(Instant.now(), payload));
+        while (messages.size() > maxSize) {
+            messages.removeLast();
+        }
+    }
+
+    /**
+     * 저장된 메시지 목록을 읽기 전용 리스트로 반환한다.
+     * @return 메시지 목록
+     */
+    public synchronized List<StoredMessage> getMessages() {
+        return Collections.unmodifiableList(List.copyOf(messages));
+    }
+
+    /**
+     * 메시지와 수신 시간을 함께 표현하는 간단한 내부 클래스.
+     * (record를 사용하면 더 간결하지만, 주석 예시를 위해 클래스로 구현)
+     */
+    public static class StoredMessage {
+        /** 메시지 수신 시각 */
+        private final Instant receivedAt;
+        /** 메시지 본문 */
+        private final String payload;
+
+        public StoredMessage(Instant receivedAt, String payload) {
+            this.receivedAt = receivedAt;
+            this.payload = payload;
+        }
+
+        public Instant getReceivedAt() {
+            return receivedAt;
+        }
+
+        public String getPayload() {
+            return payload;
+        }
+    }
+}

--- a/event-consumer/src/main/resources/application.yml
+++ b/event-consumer/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: event-consumer
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: demo-consumer
+      auto-offset-reset: latest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+demo:
+  topic-name: demo-topic

--- a/event-consumer/src/test/java/com/example/consumer/ConsumerApplicationTests.java
+++ b/event-consumer/src/test/java/com/example/consumer/ConsumerApplicationTests.java
@@ -1,0 +1,16 @@
+package com.example.consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * 컨슈머 애플리케이션이 정상적으로 로딩되는지 검증하는 기본 테스트.
+ */
+@SpringBootTest
+class ConsumerApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // 컨텍스트 로딩이 실패하지 않으면 테스트 성공으로 간주한다.
+    }
+}

--- a/event-consumer/src/test/resources/application.yml
+++ b/event-consumer/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  kafka:
+    admin:
+      auto-create: false
+      fail-fast: false
+    listener:
+      auto-startup: false

--- a/event-producer/pom.xml
+++ b/event-producer/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>simple-kafka</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>event-producer</artifactId>
+    <name>event-producer</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/event-producer/src/main/java/com/example/producer/ProducerApplication.java
+++ b/event-producer/src/main/java/com/example/producer/ProducerApplication.java
@@ -1,0 +1,24 @@
+package com.example.producer;
+
+import com.example.producer.config.AutoPublishProperties;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 애플리케이션 엔트리 포인트로, 프로듀서 서버를 실행하고 스케줄링 및 설정 바인딩을 활성화한다.
+ */
+@SpringBootApplication
+@EnableScheduling
+@EnableConfigurationProperties(AutoPublishProperties.class)
+public class ProducerApplication {
+
+    /**
+     * 스프링 부트 애플리케이션을 시작한다.
+     * @param args 커맨드라인 인자
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(ProducerApplication.class, args);
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/config/AutoPublishProperties.java
+++ b/event-producer/src/main/java/com/example/producer/config/AutoPublishProperties.java
@@ -1,0 +1,43 @@
+package com.example.producer.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 자동 발행 기능을 설정 파일과 바인딩하기 위한 프로퍼티 클래스.
+ */
+@ConfigurationProperties(prefix = "demo.auto-publish")
+public class AutoPublishProperties {
+
+    /** 자동 발행 기능 사용 여부 */
+    private boolean enabled = false;
+
+    /** 발행 간격(밀리초) */
+    private long interval = 5000L;
+
+    /** 발행에 사용할 메시지 템플릿 */
+    private String messageTemplate = "자동 발행 메시지 - %d";
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public void setInterval(long interval) {
+        this.interval = interval;
+    }
+
+    public String getMessageTemplate() {
+        return messageTemplate;
+    }
+
+    public void setMessageTemplate(String messageTemplate) {
+        this.messageTemplate = messageTemplate;
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/config/KafkaTopicConfig.java
+++ b/event-producer/src/main/java/com/example/producer/config/KafkaTopicConfig.java
@@ -1,0 +1,26 @@
+package com.example.producer.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Kafka 토픽 생성을 담당하는 설정 클래스.
+ */
+@Configuration
+public class KafkaTopicConfig {
+
+    /** 토픽 이름을 설정 파일에서 주입받는다. */
+    @Value("${demo.topic-name:demo-topic}")
+    private String topicName;
+
+    /**
+     * KafkaAdmin이 애플리케이션 시작 시 토픽을 생성할 수 있도록 NewTopic 빈을 등록한다.
+     * @return 생성할 토픽 정보
+     */
+    @Bean
+    public NewTopic demoTopic() {
+        return new NewTopic(topicName, 1, (short) 1);
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/controller/PublishController.java
+++ b/event-producer/src/main/java/com/example/producer/controller/PublishController.java
@@ -1,0 +1,40 @@
+package com.example.producer.controller;
+
+import com.example.producer.dto.PublishRequest;
+import com.example.producer.service.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST 엔드포인트를 통해 메시지를 수동 발행할 수 있는 컨트롤러.
+ */
+@RestController
+@RequestMapping("/publish")
+public class PublishController {
+
+    private static final Logger log = LoggerFactory.getLogger(PublishController.class);
+
+    /** Kafka로 메시지를 전송하는 서비스 */
+    private final EventPublisher eventPublisher;
+
+    public PublishController(EventPublisher eventPublisher) {
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * POST 요청으로 전달받은 메시지를 Kafka로 전송한다.
+     * @param request 발행 요청 본문
+     * @return 성공 응답
+     */
+    @PostMapping
+    public ResponseEntity<String> publish(@RequestBody PublishRequest request) {
+        eventPublisher.send(request.getMessage());
+        log.info("수동 발행 요청을 처리했습니다: {}", request.getMessage());
+        return ResponseEntity.ok("메시지를 발행했습니다.");
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/dto/PublishRequest.java
+++ b/event-producer/src/main/java/com/example/producer/dto/PublishRequest.java
@@ -1,0 +1,18 @@
+package com.example.producer.dto;
+
+/**
+ * REST API로 수신할 메시지 본문을 담는 DTO.
+ */
+public class PublishRequest {
+
+    /** 전송할 메시지 본문 */
+    private String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/service/AutoPublishService.java
+++ b/event-producer/src/main/java/com/example/producer/service/AutoPublishService.java
@@ -1,0 +1,46 @@
+package com.example.producer.service;
+
+import com.example.producer.config.AutoPublishProperties;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 설정에 따라 일정 주기로 메시지를 자동 발행하는 컴포넌트.
+ */
+@Component
+public class AutoPublishService {
+
+    private static final Logger log = LoggerFactory.getLogger(AutoPublishService.class);
+
+    /** 자동 발행 설정 값 */
+    private final AutoPublishProperties properties;
+
+    /** 메시지 일련번호 생성을 위한 카운터 */
+    private final AtomicLong counter = new AtomicLong();
+
+    /** 실제 Kafka 전송을 담당하는 서비스 */
+    private final EventPublisher eventPublisher;
+
+    public AutoPublishService(AutoPublishProperties properties, EventPublisher eventPublisher) {
+        this.properties = properties;
+        this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * 설정된 간격에 따라 자동 발행을 수행한다.
+     * fixedDelayString을 사용해 설정 파일에서 간격을 제어한다.
+     */
+    @Scheduled(fixedDelayString = "${demo.auto-publish.interval:5000}")
+    public void publishAutomatically() {
+        if (!properties.isEnabled()) {
+            return;
+        }
+        long sequence = counter.incrementAndGet();
+        String message = properties.getMessageTemplate().formatted(sequence);
+        eventPublisher.send(message);
+        log.info("자동으로 메시지를 발행했습니다: {}", message);
+    }
+}

--- a/event-producer/src/main/java/com/example/producer/service/EventPublisher.java
+++ b/event-producer/src/main/java/com/example/producer/service/EventPublisher.java
@@ -1,0 +1,32 @@
+package com.example.producer.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * KafkaTemplate을 사용하여 메시지를 전송하는 서비스 클래스.
+ */
+@Service
+public class EventPublisher {
+
+    /** 사용할 KafkaTemplate */
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    /** 기본 전송 토픽 이름 */
+    private final String topicName;
+
+    public EventPublisher(KafkaTemplate<String, String> kafkaTemplate,
+                          @Value("${demo.topic-name:demo-topic}") String topicName) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.topicName = topicName;
+    }
+
+    /**
+     * 지정된 메시지를 Kafka로 전송한다.
+     * @param message 전송할 메시지
+     */
+    public void send(String message) {
+        kafkaTemplate.send(topicName, message);
+    }
+}

--- a/event-producer/src/main/resources/application.yml
+++ b/event-producer/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: event-producer
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    properties:
+      # 로컬 개발 편의를 위한 idempotence 비활성화 등 추가 옵션을 여기에 정의할 수 있다.
+      linger.ms: 5
+
+demo:
+  topic-name: demo-topic
+  auto-publish:
+    enabled: false
+    interval: 5000
+    message-template: "자동 발행 메시지 - %d"

--- a/event-producer/src/test/java/com/example/producer/ProducerApplicationTests.java
+++ b/event-producer/src/test/java/com/example/producer/ProducerApplicationTests.java
@@ -1,0 +1,16 @@
+package com.example.producer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+/**
+ * 애플리케이션 컨텍스트 로딩 여부를 확인하는 기본 테스트.
+ */
+@SpringBootTest
+class ProducerApplicationTests {
+
+    @Test
+    void contextLoads() {
+        // 컨텍스트가 정상적으로 기동되는지만 확인한다.
+    }
+}

--- a/event-producer/src/test/resources/application.yml
+++ b/event-producer/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  kafka:
+    admin:
+      auto-create: false
+      fail-fast: false
+    listener:
+      auto-startup: false

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>simple-kafka</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>simple-kafka</name>
+    <description>Kafka 학습용 다중 모듈 예제</description>
+
+    <modules>
+        <module>event-producer</module>
+        <module>event-consumer</module>
+    </modules>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.boot.version>3.2.5</spring.boot.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring.boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
## Summary
- set up a multi-module Maven project with producer and consumer Spring Boot services for Kafka experimentation
- implement REST APIs, scheduled publishing, and message storage with Korean inline documentation for clarity
- provide Docker Compose for Kafka/Zookeeper and update documentation with usage instructions

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68e27c0eb0b483248b3001b5c522595c