### PR TITLE
Configure consumer application port to 8081

### DIFF
--- a/event-consumer/src/main/resources/application.yml
+++ b/event-consumer/src/main/resources/application.yml
@@ -8,6 +8,8 @@ spring:
       auto-offset-reset: latest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+server:
+  port: 8081
 
 demo:
   topic-name: demo-topic


### PR DESCRIPTION
## Summary
- configure the consumer Spring Boot application to listen on port 8081
- verified that the README example already references the 8081 endpoint, so the documentation matches the configuration

## Testing
- not run (Kafka services not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e282ef3ba08324a2b97b0cf7cff50f